### PR TITLE
Fix deprecated PropTypes usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss-nested": "^1.0.0",
     "postcss-reporter": "^3.0.0",
     "postcss-responsive-type": "^0.5.0",
+    "prop-types": "^15.5.10",
     "react": "^15.0.0",
     "react-addons-shallow-compare": "^15.0.0",
     "react-dates": "^12.1.0",
@@ -36,6 +37,7 @@
     "webpack": "^1.13.1"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.0.0",
     "react-dates": "^12.1.0",
     "react-dom": "^15.0.0"

--- a/src/DatePresetPicker.js
+++ b/src/DatePresetPicker.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import _ from 'lodash';
 import moment from 'moment';

--- a/src/RangeButton.js
+++ b/src/RangeButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import styles from './DatePresetPicker.css';
 


### PR DESCRIPTION
Hey!

Since React 15.5 using proptypes via React.PropTypes is deprecated (https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html). 

These minor changes fixes these deprecation warnings and prepares the library for React 16.

React-dates already has a dependency on the `prop-types` package, so this doesn't add any new bloat :)